### PR TITLE
use a pyscript.conf to make updating easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here are the steps to install the pyscript kernel for Jupyter:
 * Download and extract the latest `hass-pyscript-jupyter-X.XX.zip` file from
 [releases](https://github.com/craigbarratt/hass-pyscript-jupyter/releases) into
 `KERNEL_DIRECTORY/pyscript`.  Alternatively, you can download the current master version
-of the files (`kernel.json`, `hass_pyscript_kernel.py` and the two logo files) in this directory.
+of the files (`kernel.json`, `hass_pyscript_kernel.py`, `pyscript.conf`, and the two logo files) in this directory.
     <details><summary>Click to see the direct download commands</summary>
 
     ```
@@ -34,6 +34,7 @@ of the files (`kernel.json`, `hass_pyscript_kernel.py` and the two logo files) i
     wget https://github.com/craigbarratt/hass-pyscript-jupyter/raw/master/hass_pyscript_kernel.py
     wget https://github.com/craigbarratt/hass-pyscript-jupyter/raw/master/logo-32x32.png
     wget https://github.com/craigbarratt/hass-pyscript-jupyter/raw/master/logo-64x64.png
+    wget https://github.com/craigbarratt/hass-pyscript-jupyter/raw/master/pyscript.conf
     ```
     </details>
 
@@ -41,10 +42,10 @@ of the files (`kernel.json`, `hass_pyscript_kernel.py` and the two logo files) i
     - replace KERNEL_DIRECTORY by the directory determined above.
     - check the `python` entry in `argv` to make sure it is the latest version of python
       on your system (eg, you might need to replace with `python3`)
-* Edit `hass_pyscript_kernel.py` and replace the settings of:
-    - `HASS_HOST` with the host name or IP address where your HASS instance is running
-    - `HASS_URL` with the URL of your HASS httpd service
-    - `HASS_TOKEN` with a long-lived access token created via the button at the bottom of
+* Edit `pyscript.conf` and replace the settings of:
+    - `hass_host` with the host name or IP address where your HASS instance is running
+    - `hass_url` with the URL of your HASS httpd service
+    - `hass_token` with a long-lived access token created via the button at the bottom of
        your user profile page in HASS.
     - Since you've added a HASS access token to this file, you should make sure you are
       comfortable with file permissions - anyone who can read this file could use the

--- a/hass_pyscript_kernel.py
+++ b/hass_pyscript_kernel.py
@@ -11,36 +11,28 @@
 
 import argparse
 import asyncio
+import configparser
 import json
 import requests
 import secrets
 import sys
 import traceback
-
-#
-# Set HASS_HOST to the host name or IP address where your HASS is running.
-# This should be a host name or IP address you can ping from the Jupyter
-# client machine. e.g., "192.168.1.10" or "homeassistant".
-#
-HASS_HOST = "YOUR_HASS_HOST_OR_IP"
-
-#
-# Set HASS_URL to the URL of your HASS http interface. Typically the host
-# name portion will be the same as HASS_HOST above.
-# e.g., http://my-homeassistant.duckdns.org/ or "http://192.168.1.10:8123".
-#
-HASS_URL = "http://YOUR_HASS_HOST_OR_IP:8123"
-
-#
-# Set HASS_TOKEN to a long-term access token created via the button
-# at the bottom of your user profile page in HASS.
-#
-HASS_TOKEN = "REPLACE_WITH_THE_LONG_TERM_ACCESS_KEY_FROM_HASS"
+from pathlib import Path
 
 #
 # Our program name we print when --verbose is used
 #
-SCRIPT_NAME = "hass_pyscript_kernel.py"
+this_file = Path(__file__).resolve()
+SCRIPT_NAME = this_file.name
+
+#
+# Read the Home Assistant connection settings from the config file
+#
+config = configparser.ConfigParser()
+config.read(this_file.parent / "pyscript.conf")
+HASS_HOST = config["homeassistant"]["hass_host"]
+HASS_URL = config["homeassistant"]["hass_url"]
+HASS_TOKEN = config["homeassistant"]["hass_token"]
 
 
 def do_request(url, headers, data=None):

--- a/pyscript.conf
+++ b/pyscript.conf
@@ -1,0 +1,18 @@
+[homeassistant]
+#
+# Set hass_host to the host name or IP address where your HASS is running.
+# This should be a host name or IP address you can ping from the Jupyter
+# client machine. e.g., `192.168.1.10` or `homeassistant`.
+#
+hass_host = YOUR_HASS_HOST_OR_IP
+#
+# Set hass_url to the URL of your HASS http interface. Typically the host
+# name portion will be the same as hass_host above.
+# e.g., http://my-homeassistant.duckdns.org/ or http://192.168.1.10:8123.
+#
+hass_url = http://YOUR_HASS_HOST_OR_IP:8123
+#
+# Set hass_token to a long-term access token created via the button
+# at the bottom of your user profile page in HASS.
+#
+hass_token = REPLACE_WITH_THE_LONG_TERM_ACCESS_KEY_FROM_HASS


### PR DESCRIPTION
Each time there is an update to the script one needs to manually
edit the overwritten `hass_pyscript_kernel.py` file. Now that there is a configuration
file, one can simply replace the Python file without editing.