### PR TITLE
Support vscode-server Jupyter extensions

### DIFF
--- a/hass_pyscript_kernel/install.py
+++ b/hass_pyscript_kernel/install.py
@@ -50,6 +50,11 @@ def install(target_dir, kernel_name):
         "argv": argv,
         "display_name": f"hass {kernel_name}",
         "language": "python",
+        "metadata": {
+            "interpreter": {
+                "path": "python"
+            }
+        }
     }
 
     with open(os.path.join(target_dir, "kernel.json"), "w") as ofd:


### PR DESCRIPTION
Take a look at https://github.com/quantapix/qnarre2/blob/06b41b6754f692f208efccf91bd62fd2feb265c4/proba/client/src-py/datascience/jupyter/kernels/kernelService.ts#L156
Requires extra metadata to confirm that the binary in fact exists instead of just parsing the argv. Otherwise you get "Kernel Spec for hass pyscript ignored as we cannot find a matching interpreter" as an error.