### PR TITLE
Fix kernel error caused by aiohttp

### DIFF
--- a/hass_pyscript_kernel/shim.py
+++ b/hass_pyscript_kernel/shim.py
@@ -236,12 +236,12 @@ async def kernel_run(config: dict, verbose: int) -> None:
     session = aiohttp.ClientSession(connector=connector, headers=headers, raise_for_status=True)
 
     async def do_request(
-        url: StrOrURL, data: Any = None, json_data: Any = None, **kwargs: Any
+        url: StrOrURL, data: Any = None, json_data: Any = None
     ) -> ClientResponse:
         """Do a GET or POST with the given URL."""
         try:
             method = "POST" if data or json_data else "GET"
-            return await session.request(method=method, url=url, data=data, json=json_data, **kwargs)
+            return await session.request(method=method, url=url, data=data, json=json_data)
         except aiohttp.ClientSSLError as err:  # Help diagnose if issue is an SSL Certificate error
             print(f"{PKG_NAME}: got SSL error {err}")
             sys.exit(1)


### PR DESCRIPTION
do_request was causing an error because of some aiohttp stuff:

Channel.getaddrinfo() takes 3 positional arguments but 4 positional arguments (and 4 keyword-only arguments) were given
(url=http://localhost:8123/api/services/pyscript/jupyter_kernel_start)

Fixed by removing kwargs from do_request which were unused anyway.