### PR TITLE
Add ipykernel requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "aiohttp_socks",
         "jupyter-client",
         "jupyter-core",
+        "ipykernel"
     ],
     python_requires=">=3.7",
     zip_safe=False,


### PR DESCRIPTION
Added ipykernel requirement to setup.py so it installs correctly in venv etc.. Without it it was trying to install in system path and hitting permission error.

Will stop users from struggling with install in venv like in #27 #25 